### PR TITLE
Fix image wrapping and regex issues

### DIFF
--- a/includes/class-support.php
+++ b/includes/class-support.php
@@ -25,7 +25,7 @@ final class Support
 
     public function wrapAttachment(string $html, int $attachmentId, $size, bool $icon, array $attr): string
     {
-        if (str_contains($html, '<picture') || str_contains($html, 'type="image/avif"')) {
+        if (str_contains($html, '<picture')) {
             return $html;
         }
 


### PR DESCRIPTION
Remove over-broad `type="image/avif"` early return in `wrapAttachment()` to prevent valid images from being skipped.

The original condition `str_contains($html, 'type="image/avif"')` caused `wrapAttachment()` to exit early if *any* AVIF content was present in the HTML string, even if the specific attachment being processed was a JPEG. This change ensures `wrapAttachment()` only skips processing if the image is already part of a `<picture>` element, preventing double-wrapping without incorrectly skipping other valid images.

---
<a href="https://cursor.com/background-agent?bcId=bc-41e3b181-2675-4dc6-bea6-ff540e2b2c51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-41e3b181-2675-4dc6-bea6-ff540e2b2c51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

