### PR TITLE
Fix time input and scheduling for AVIF conversion

### DIFF
--- a/includes/class-avif-suite.php
+++ b/includes/class-avif-suite.php
@@ -185,9 +185,8 @@ final class Plugin
                 echo '<label for="avif_local_support_convert_via_schedule">'
                     . '<input id="avif_local_support_convert_via_schedule" type="checkbox" name="avif_local_support_convert_via_schedule" value="1" ' . checked(true, $enabled, false) . ' /> '
                     . esc_html__('Scan daily and convert missing AVIFs', 'avif-local-support')
-                    . '</label>';
-                echo '<br><label for="avif_local_support_schedule_time">' . esc_html__('Time (24h):', 'avif-local-support') . ' '
-                    . '<input id="avif_local_support_schedule_time" type="time" name="avif_local_support_schedule_time" value="' . \esc_attr($time) . '" /></label>';
+                    . '</label> ';
+                echo '<input id="avif_local_support_schedule_time" type="time" name="avif_local_support_schedule_time" value="' . \esc_attr($time) . '" aria-label="' . esc_attr__('Time', 'avif-local-support') . '" />';
             },
             'avif-local-support',
             'avif_local_support_conversion',

--- a/includes/class-converter.php
+++ b/includes/class-converter.php
@@ -43,8 +43,8 @@ final class Converter
             $time = '01:00';
         }
         [$hour, $minute] = array_map('intval', explode(':', $time));
-        $now = (int) current_time('timestamp');
-        // Use DateTime with site timezone and gmdate for safe comparisons
+        $now = (int) current_time('timestamp', true);
+        // Use DateTime with site timezone and compare using GMT epoch for correctness
         $tz = wp_timezone();
         $dt = new \DateTimeImmutable('@' . $now);
         $dt = $dt->setTimezone($tz);


### PR DESCRIPTION
Improve the "Scan daily and convert missing AVIFs" UI by aligning the time input and removing the "Time (24h)" label, while ensuring robust scheduling.

The "Time (24h)" label was removed because browser `type="time"` inputs often display a 12-hour clock with AM/PM, making the label misleading. The scheduling logic was updated to use GMT timestamps for comparisons, ensuring the daily scan consistently runs at the user's chosen local time across different timezones.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca14d626-4e0c-4400-acf6-168e2f00e391">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca14d626-4e0c-4400-acf6-168e2f00e391">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

