### PR TITLE
Fix parse_url and slow query

### DIFF
--- a/includes/class-converter.php
+++ b/includes/class-converter.php
@@ -362,7 +362,6 @@ final class Converter
             'post_status' => 'inherit',
             'posts_per_page' => -1,
             'fields' => 'ids',
-            'meta_query' => [],
         ]);
         $count = 0;
         foreach ($query->posts as $attachmentId) {

--- a/includes/class-support.php
+++ b/includes/class-support.php
@@ -79,7 +79,7 @@ final class Support
         if (!$this->isUploadsImage($jpegUrl)) {
             return null;
         }
-        $parts = \parse_url($jpegUrl);
+        $parts = \wp_parse_url($jpegUrl);
         if ($parts === false || empty($parts['path'])) {
             return null;
         }


### PR DESCRIPTION
Replaced `parse_url` with `wp_parse_url` and removed an empty `meta_query` to address linter warnings and improve consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-759266f6-1a48-4df1-810a-1054786e5330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-759266f6-1a48-4df1-810a-1054786e5330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

