### PR TITLE
Check wordpress plugin conventions and security

### DIFF
--- a/avif-local-support.php
+++ b/avif-local-support.php
@@ -23,8 +23,9 @@ declare(strict_types=1);
 // Define constants
 \define('AVIFLOSU_VERSION', '0.1.2');
 \define('AVIFLOSU_PLUGIN_FILE', __FILE__);
-\define('AVIFLOSU_PLUGIN_DIR', __DIR__);
-\define('AVIFLOSU_INC_DIR', __DIR__ . '/includes');
+\define('AVIFLOSU_PLUGIN_DIR', plugin_dir_path(__FILE__));
+\define('AVIFLOSU_PLUGIN_URL', plugin_dir_url(__FILE__));
+\define('AVIFLOSU_INC_DIR', AVIFLOSU_PLUGIN_DIR . 'includes');
 
 // Includes (simple autoload)
 require_once AVIFLOSU_INC_DIR . '/class-avif-suite.php';
@@ -47,7 +48,7 @@ add_action('init', 'aviflosu_init');
 // i18n: WordPress.org will auto-load translations for plugins hosted there.
 // Keeping manual loader disabled to satisfy Plugin Check recommendations.
 
-// Activation / Deactivation / Uninstall
+// Activation / Deactivation
 function aviflosu_activate(): void
 {
 	// Ensure defaults
@@ -83,29 +84,4 @@ function aviflosu_deactivate(): void
 
 register_activation_hook(__FILE__, 'aviflosu_activate');
 register_deactivation_hook(__FILE__, 'aviflosu_deactivate');
-register_uninstall_hook(__FILE__, 'aviflosu_uninstall');
-
-function aviflosu_uninstall(): void
-{
-	// Delete only options created by this plugin
-	$options = [
-		'aviflosu_enable_support',
-		'aviflosu_convert_on_upload',
-		'aviflosu_convert_via_schedule',
-		'aviflosu_schedule_time',
-		'aviflosu_quality',
-		'aviflosu_speed',
-		'aviflosu_preserve_metadata',
-		'aviflosu_preserve_color_profile',
-		'aviflosu_wordpress_logic',
-		'aviflosu_cache_duration',
-	];
-
-	foreach ($options as $option) {
-		if (\get_option($option) !== false) {
-			\delete_option($option);
-		}
-	}
-	// Clean transients
-	\delete_transient('aviflosu_file_cache');
-}
+// Uninstall is handled by uninstall.php

--- a/includes/class-avif-suite.php
+++ b/includes/class-avif-suite.php
@@ -50,9 +50,9 @@ final class Plugin
         if ($hook !== 'settings_page_avif-local-support') {
             return;
         }
-        $base = plugins_url('', \AVIFLOSU_PLUGIN_FILE);
-        wp_enqueue_style('avif-local-support-admin', $base . '/assets/admin.css', [], \AVIFLOSU_VERSION);
-        wp_enqueue_script('avif-local-support-admin', $base . '/assets/admin.js', [], \AVIFLOSU_VERSION, true);
+        $base = \AVIFLOSU_PLUGIN_URL;
+        wp_enqueue_style('avif-local-support-admin', $base . 'assets/admin.css', [], \AVIFLOSU_VERSION);
+        wp_enqueue_script('avif-local-support-admin', $base . 'assets/admin.js', [], \AVIFLOSU_VERSION, true);
         wp_localize_script('avif-local-support-admin', 'AVIFLocalSupportData', [
             'ajaxUrl' => admin_url('admin-ajax.php'),
             'scanNonce' => wp_create_nonce('aviflosu_scan_missing'),
@@ -463,7 +463,7 @@ final class Plugin
         echo '    <div class="postbox">';
         echo '      <h2 class="hndle"><span>' . esc_html__('About', 'avif-local-support') . '</span></h2>';
         echo '      <div class="inside">';
-        $readme_path = \AVIFLOSU_PLUGIN_DIR . '/readme.txt';
+        $readme_path = \AVIFLOSU_PLUGIN_DIR . 'readme.txt';
         if (file_exists($readme_path) && is_readable($readme_path)) {
             $readme_contents = @file_get_contents($readme_path);
             if ($readme_contents !== false) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+	exit;
+}
+
+$options = [
+	'aviflosu_enable_support',
+	'aviflosu_convert_on_upload',
+	'aviflosu_convert_via_schedule',
+	'aviflosu_schedule_time',
+	'aviflosu_quality',
+	'aviflosu_speed',
+	'aviflosu_preserve_metadata',
+	'aviflosu_preserve_color_profile',
+	'aviflosu_wordpress_logic',
+	'aviflosu_cache_duration',
+];
+
+foreach ($options as $option) {
+	if (get_option($option) !== false) {
+		delete_option($option);
+	}
+}
+
+delete_transient('aviflosu_file_cache');


### PR DESCRIPTION
Move uninstall logic to `uninstall.php` and use `plugin_dir_path`/`plugin_dir_url` for constants to follow WordPress best practices.

---
<a href="https://cursor.com/background-agent?bcId=bc-58d0eb05-1b05-429f-bd0c-3c279f0ae3c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-58d0eb05-1b05-429f-bd0c-3c279f0ae3c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

