### PR TITLE
Add uploads scan, lazy tools stats, missing-files panel, and small-AV…

### DIFF
--- a/includes/Admin/RestController.php
+++ b/includes/Admin/RestController.php
@@ -52,6 +52,24 @@ final class RestController
 
 		register_rest_route(
 			self::NAMESPACE ,
+			'/missing-files',
+			array(
+				'methods' => 'GET',
+				'permission_callback' => array($this, 'permissionManageOptions'),
+				'callback' => array($this, 'missingFiles'),
+				'args' => array(
+					'limit' => array(
+						'required' => false,
+						'type' => 'integer',
+						'default' => 200,
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE ,
 			'/convert-now',
 			array(
 				'methods' => 'POST',
@@ -230,6 +248,15 @@ final class RestController
 	public function scanMissing(\WP_REST_Request $request): \WP_REST_Response
 	{
 		return rest_ensure_response($this->diagnostics->computeMissingCounts());
+	}
+
+	public function missingFiles(\WP_REST_Request $request): \WP_REST_Response
+	{
+		$limit = (int) $request->get_param('limit');
+		if ($limit <= 0) {
+			$limit = 200;
+		}
+		return rest_ensure_response($this->diagnostics->getMissingFiles($limit));
 	}
 
 	public function convertNow(\WP_REST_Request $request): \WP_REST_Response

--- a/includes/Encoders/CliEncoder.php
+++ b/includes/Encoders/CliEncoder.php
@@ -263,9 +263,9 @@ class CliEncoder implements AvifEncoderInterface {
 			return $this->analyzeError();
 		}
 
-		if ( ! file_exists( $destination ) || filesize( $destination ) <= 512 ) {
+		if ( ! file_exists( $destination ) || filesize( $destination ) <= 0 ) {
 			return ConversionResult::failure(
-				'CLI reported success but file is missing or empty.',
+				'CLI reported success but file is missing or zero bytes.',
 				'Verify that your ImageMagick build supports AVIF writing.'
 			);
 		}

--- a/includes/Encoders/ImagickEncoder.php
+++ b/includes/Encoders/ImagickEncoder.php
@@ -148,12 +148,12 @@ class ImagickEncoder implements AvifEncoderInterface {
 			$im->writeImage( $destination );
 			$im->destroy();
 
-			if ( file_exists( $destination ) && filesize( $destination ) > 512 ) {
+			if ( file_exists( $destination ) && filesize( $destination ) > 0 ) {
 				return ConversionResult::success();
 			}
 
 			return ConversionResult::failure(
-				'Imagick produced invalid AVIF',
+				'Imagick did not produce a usable AVIF',
 				'Your ImageMagick build may lack AVIF write support.'
 			);
 

--- a/includes/class-avif-suite.php
+++ b/includes/class-avif-suite.php
@@ -100,6 +100,13 @@ final class Plugin {
 				'avifDeleting'              => __( 'Deleting AVIF files...', 'avif-local-support' ),
 				'avifDeletedPrefix'         => __( 'Deleted AVIF files:', 'avif-local-support' ),
 				'avifFailedPrefix'          => __( 'Failed:', 'avif-local-support' ),
+				'avifStatsLoading'          => __( 'Loading AVIF stats...', 'avif-local-support' ),
+				'avifStatsLoadFailed'       => __( 'Could not load AVIF stats.', 'avif-local-support' ),
+				'missingFilesLoading'       => __( 'Loading files without AVIF...', 'avif-local-support' ),
+				'missingFilesNone'          => __( 'All discovered JPEG files already have AVIF.', 'avif-local-support' ),
+				'missingFilesListed'        => __( 'files without AVIF listed.', 'avif-local-support' ),
+				'missingFilesTruncated'     => __( 'Showing first 200.', 'avif-local-support' ),
+				'missingFilesLoadFailed'    => __( 'Could not load files without AVIF.', 'avif-local-support' ),
 				'lqipStopping'             => __( 'Stopping LQIP generation...', 'avif-local-support' ),
 				'lqipStopped'              => __( 'LQIP generation stopped.', 'avif-local-support' ),
 				'lqipStopFailed'           => __( 'Could not request LQIP stop.', 'avif-local-support' ),
@@ -198,17 +205,8 @@ final class Plugin {
 		}
 		ob_end_clean();
 
-		ob_start();
-		try {
-			$stats = $this->diagnostics->computeMissingCounts();
-		} catch ( \Throwable $e ) {
-			$stats = array(
-				'total_jpegs'    => 0,
-				'existing_avifs' => 0,
-				'missing_avifs'  => 0,
-			);
-		}
-		ob_end_clean();
+		// AVIF counts are lazy-loaded via REST in admin.js to keep initial page load fast.
+		$stats = array();
 
 		$settings = array(
 			'engine_mode'       => (string) get_option( 'aviflosu_engine_mode', 'auto' ),

--- a/templates/admin/tab-tools.php
+++ b/templates/admin/tab-tools.php
@@ -106,6 +106,9 @@ $auto_first_label   = match ( $auto_first_attempt ) {
 	'gd' => esc_html__( 'GD (imageavif)', 'avif-local-support' ),
 	default => esc_html__( 'None', 'avif-local-support' ),
 };
+$format_avif_stat = static function ( $value ): string {
+	return is_numeric( $value ) ? (string) (int) $value : '...';
+};
 ?>
 <div id="avif-local-support-tab-tools" class="avif-local-support-tab">
 	<div class="avif-settings-form avif-tools-layout">
@@ -119,18 +122,22 @@ $auto_first_label   = match ( $auto_first_attempt ) {
 				<tbody>
 					<tr>
 						<th scope="row"><?php esc_html_e( 'JPEG Files', 'avif-local-support' ); ?></th>
-						<td><span id="avif-local-support-total-jpegs"><?php echo (int) ( $stats['total_jpegs'] ?? 0 ); ?></span></td>
+						<td><span id="avif-local-support-total-jpegs"><?php echo esc_html( $format_avif_stat( $stats['total_jpegs'] ?? null ) ); ?></span></td>
 					</tr>
 					<tr>
 						<th scope="row"><?php esc_html_e( 'With AVIF', 'avif-local-support' ); ?></th>
-						<td><span id="avif-local-support-existing-avifs"><?php echo (int) ( $stats['existing_avifs'] ?? 0 ); ?></span></td>
+						<td><span id="avif-local-support-existing-avifs"><?php echo esc_html( $format_avif_stat( $stats['existing_avifs'] ?? null ) ); ?></span></td>
 					</tr>
 					<tr>
 						<th scope="row"><?php esc_html_e( 'Without AVIF', 'avif-local-support' ); ?></th>
-						<td><span id="avif-local-support-missing-avifs"><?php echo (int) ( $stats['missing_avifs'] ?? 0 ); ?></span></td>
+						<td><span id="avif-local-support-missing-avifs"><?php echo esc_html( $format_avif_stat( $stats['missing_avifs'] ?? null ) ); ?></span></td>
 					</tr>
 				</tbody>
 			</table>
+			<p id="avif-local-support-stats-loading" class="description">
+				<span class="spinner is-active avif-spinner-inline"></span>
+				<?php esc_html_e( 'Loading AVIF stats...', 'avif-local-support' ); ?>
+			</p>
 
 			<div class="avif-actions-row">
 				<button type="button" class="button button-primary" id="avif-local-support-convert-now"><?php esc_html_e( 'Generate Missing AVIF', 'avif-local-support' ); ?></button>
@@ -285,8 +292,27 @@ $auto_first_label   = match ( $auto_first_attempt ) {
 			</div>
 		</section>
 
-		<section class="avif-tools-section">
-			<h3><?php esc_html_e( 'Logs', 'avif-local-support' ); ?></h3>
+			<section class="avif-tools-section">
+				<h3><?php esc_html_e( 'Files Without AVIF', 'avif-local-support' ); ?></h3>
+				<p class="description">
+					<?php esc_html_e( 'Review JPEG files that do not currently have a generated AVIF companion.', 'avif-local-support' ); ?>
+				</p>
+				<details id="avif-local-support-missing-files-panel">
+					<summary><strong><?php esc_html_e( 'Show Missing File List', 'avif-local-support' ); ?></strong></summary>
+					<div class="avif-actions-row">
+						<button type="button" class="button button-secondary" id="avif-local-support-refresh-missing-files">
+							<?php esc_html_e( 'Refresh List', 'avif-local-support' ); ?>
+						</button>
+					</div>
+					<p id="avif-local-support-missing-files-status" class="description"></p>
+					<div id="avif-local-support-missing-files-wrap" class="avif-logs-container hidden">
+						<ul id="avif-local-support-missing-files-list" class="avif-binary-list"></ul>
+					</div>
+				</details>
+			</section>
+
+			<section class="avif-tools-section">
+				<h3><?php esc_html_e( 'Logs', 'avif-local-support' ); ?></h3>
 			<p class="description">
 				<?php esc_html_e( 'View recent conversion logs including errors, settings used, and performance metrics.', 'avif-local-support' ); ?>
 			</p>


### PR DESCRIPTION
## Summary

This PR improves AVIF coverage and admin UX for sites that generate JPEG files outside standard attachment metadata (for example, theme/plugin gallery derivatives), and reduces load on the Tools screen.

The core goals were:

1. Ensure AVIF conversion/discovery includes **all JPEGs in `/wp-content/uploads`**, not only Media Library-registered files.
2. Ensure frontend delivery rewrites also cover common **lightbox/gallery attributes and linked JPEG URLs**.
3. Reduce Tools page load cost by moving expensive AVIF stats/file discovery into **lazy REST calls**.
4. Make it easier to identify conversion gaps via a dedicated **“Files Without AVIF”** panel.
5. Stop incorrectly treating tiny but valid AVIF files as missing/invalid.

---

## Reasoning / Why This Is Needed

On real-world sites (including mine), themes like Kadence generate additional image sizes that are stored in uploads but are not always represented in Media Library metadata the same way core sizes are.  
When scanning only attachment metadata, those files can be missed, which leads to:

- missing AVIF companions for gallery/lightbox images,
- JPEGs still being served in certain frontend interactions,
- inaccurate “missing AVIF” counts.

Also, opening the plugin’s main Tools/admin screen was expensive on large media libraries because stats were computed server-side during page render, contributing to high query/load overhead.

Finally, tiny generated thumbnails can produce very small AVIF files. A hard `>512 bytes` check can misclassify valid AVIFs as missing/failed.

---

## What Changed

### 1) Uploads-Folder Coverage Beyond Media Metadata
- Added recursive scan support so missing-count logic and conversion routines include JPEGs under uploads even when not discoverable through attachment metadata alone.
- Conversion loop now scans uploads after attachment pass, with stop-flag support preserved for long-running operations.

### 2) Frontend AVIF Rewriting for Lightbox/Linked Images
- Extended frontend rewrite behavior so AVIF URL substitution also updates:
  - common lightbox image data attributes (for full/light image URLs),
  - nearest linked JPEG anchors (when AVIF exists).
- This addresses gallery/lightbox flows that do not rely only on `img src/srcset`.

### 3) Lazy-Loaded Tools Metrics via REST
- Loading the plugin's options page would take multiple seconds before the page would load.
- AVIF stats are no longer fully computed at initial page render for Tools.
- Admin JS now fetches counts asynchronously from REST, with loading status and failure fallback text.

### 4) New “Files Without AVIF” UI Section
- Added dedicated Tools segment for “Files Without AVIF”.
- Section is collapsible and collapsed by default.
- Includes refresh action and displays a capped list (with truncation indicator when applicable).
- Positioned above Logs for easier operator workflow.

### 5) Missing-Files REST Endpoint
- Added endpoint for missing JPEG list retrieval (with limit parameter and capability checks), used by the new panel.

### 6) Small AVIF Validity Fix
- Replaced strict `>512 bytes` AVIF validity checks with `>0 bytes` existence checks in relevant conversion/diagnostic paths.
- Prevents false “missing/invalid” for tiny but valid AVIF outputs (common on very small thumbnails).

---

## Files Touched

- `includes/class-converter.php`
- `includes/class-support.php`
- `includes/Diagnostics.php`
- `includes/Admin/RestController.php`
- `includes/class-avif-suite.php`
- `templates/admin/tab-tools.php`
- `assets/admin.js`
- `includes/Encoders/CliEncoder.php`
- `includes/Encoders/ImagickEncoder.php`

---

## Backward Compatibility / Risk Notes

- Changes are additive and scoped to AVIF discovery/delivery/admin UI.
- Existing settings and REST permission model are preserved.
- Recursive uploads scanning can increase filesystem traversal, but is intentional to close conversion gaps for non-metadata derivatives.
- Missing-file list endpoint is capped and supports limit to avoid excessive payloads.

---

## Testing Performed

- Verified PHP syntax for modified PHP files.
- Validated Tools page:
  - loads quickly with deferred stats request,
  - shows loading state then counts,
  - shows dedicated “Files Without AVIF” section above logs,
  - section is collapsible and collapsed by default,
  - refresh updates list/status.
- Verified frontend rewrite behavior for gallery/lightbox-style markup with linked JPEGs and lightbox data attributes.
- Verified tiny AVIF files are no longer falsely counted as missing due to 512-byte threshold.